### PR TITLE
Attempt at fixing existing filename issue when exporting

### DIFF
--- a/pkg/disk.go
+++ b/pkg/disk.go
@@ -74,6 +74,22 @@ func (a *albumDiskInfo) IsMetaFileNamePresent(metaFileName string) bool {
 	return ok
 }
 
+// GenerateUniqueMetaFileName generates a unique metafile name.
+func (a *albumDiskInfo) GenerateUniqueMetaFileName(baseFileName, extension string) string {
+	potentialDiskFileName := fmt.Sprintf("%s%s.json", baseFileName, extension)
+	count := 1
+	for a.IsMetaFileNamePresent(potentialDiskFileName) {
+		// separate the file name and extension
+		fileName := fmt.Sprintf("%s_%d", baseFileName, count)
+		potentialDiskFileName = fmt.Sprintf("%s%s.json", fileName, extension)
+		count++
+		if !a.IsMetaFileNamePresent(potentialDiskFileName) {
+			break
+		}
+	}
+	return potentialDiskFileName
+}
+
 // GenerateUniqueFileName generates a unique file name.
 func (a *albumDiskInfo) GenerateUniqueFileName(baseFileName, extension string) string {
 	fileName := fmt.Sprintf("%s%s", baseFileName, extension)

--- a/pkg/disk_test.go
+++ b/pkg/disk_test.go
@@ -1,0 +1,32 @@
+package pkg
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGenerateUniqueFileName(t *testing.T) {
+	existingFilenames := make(map[string]bool)
+	testFilename := "FullSizeRender.jpg" // what Apple calls shared files
+
+	existingFilenames[strings.ToLower(testFilename)] = true
+
+	a := &albumDiskInfo{
+		FileNames: &existingFilenames,
+	}
+
+	// this is taken from downloadEntry()
+	extension := filepath.Ext(testFilename)
+	baseFileName := strings.TrimSuffix(filepath.Clean(filepath.Base(testFilename)), extension)
+
+	for i := 0; i < 100; i++ {
+		newFilename := a.GenerateUniqueFileName(baseFileName, extension)
+		if strings.Contains(newFilename, "_1_2") {
+			t.Fatalf("Filename contained _1_2")
+		} else {
+			// add generated name to existing files
+			existingFilenames[strings.ToLower(newFilename)] = true
+		}
+	}
+}

--- a/pkg/remote_to_disk_file.go
+++ b/pkg/remote_to_disk_file.go
@@ -124,17 +124,7 @@ func (c *ClICtrl) downloadEntry(ctx context.Context,
 		// Get the extension
 		extension := filepath.Ext(fileDiskMetadata.Title)
 		baseFileName := strings.TrimSuffix(filepath.Clean(filepath.Base(fileDiskMetadata.Title)), extension)
-		potentialDiskFileName := fmt.Sprintf("%s%s.json", baseFileName, extension)
-		count := 1
-		for diskInfo.IsMetaFileNamePresent(potentialDiskFileName) {
-			// separate the file name and extension
-			baseFileName = fmt.Sprintf("%s_%d", baseFileName, count)
-			potentialDiskFileName = fmt.Sprintf("%s%s.json", baseFileName, extension)
-			count++
-			if !diskInfo.IsMetaFileNamePresent(potentialDiskFileName) {
-				break
-			}
-		}
+		diskMetaFileName := diskInfo.GenerateUniqueMetaFileName(baseFileName, extension)
 		if file.IsLivePhoto() {
 			imagePath, videoPath, err := UnpackLive(*decrypt)
 			if err != nil {
@@ -176,13 +166,13 @@ func (c *ClICtrl) downloadEntry(ctx context.Context,
 			fileDiskMetadata.AddFileName(fileName)
 		}
 
-		fileDiskMetadata.MetaFileName = potentialDiskFileName
+		fileDiskMetadata.MetaFileName = diskMetaFileName
 		err = diskInfo.AddEntry(fileDiskMetadata)
 		if err != nil {
 			return err
 		}
 
-		err = writeJSONToFile(filepath.Join(diskInfo.ExportRoot, diskInfo.AlbumMeta.FolderName, ".meta", potentialDiskFileName), fileDiskMetadata)
+		err = writeJSONToFile(filepath.Join(diskInfo.ExportRoot, diskInfo.AlbumMeta.FolderName, ".meta", diskMetaFileName), fileDiskMetadata)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
I'm not 100% on how the metadata name is being used with the filename, but it appears that the baseFileName was being set continuously before.

`baseFileName = fmt.Sprintf("%s_%d", baseFileName, count)`

My attempt at fixing it was to break the logic into GenerateUniqueMetaFileName(), which is very similar to GenerateUniqueFileName().  This both puts the similar logic visually near each other in the files, and removes the repeated setting of baseFileName.